### PR TITLE
refactor(parser.beaver): removed beaver's special syntax

### DIFF
--- a/Lab2/src/frontend/parser.beaver
+++ b/Lab2/src/frontend/parser.beaver
@@ -59,21 +59,23 @@ EBNF Notation:
 // We define them here to avoid ambiguity later on
 // through forms such as Import = "" | concreteImport
 // in EBNF: Module = IDENT "{" imports, dec "}"
-Module = MODULE ID LCURLY ImportList Declaration* RCURLY;
+Module = MODULE ID LCURLY ImportList DeclarationList RCURLY;
 
 // An import statement consists of 0 or more import statements.
 // As explained above, we omit the optional declaration here in favour of expressing it in Module.
 // In EBNF: Import = "import" IDENT ";"
 Import = IMPORT ID SEMICOLON;
 
-ImportList = Import | ImportList Import | ;
+ImportList = Import ImportList | ;
 
 // A declaration is function or type or field declaration
 Declaration = FuncDec | TypeDec | FieldDec;
 
+DeclarationList = Declaration DeclarationList | ;
+
 // A function declaration consists of a few things but it'll be omitted here for brevity
 // in EBNF: FuncDec = Accessibility Type IDENT "(" ParamList ")" "{" Statements? "}"
-FuncDec = AccSpec Type ID LPAREN OptParamList RPAREN LCURLY Statement* RCURLY;
+FuncDec = AccSpec Type ID LPAREN OptParamList RPAREN LCURLY StatementList RCURLY;
 
 // Equivalent to matching either paramlist or nothing
 OptParamList = ParamList | ;
@@ -92,7 +94,6 @@ AccSpec = PUBLIC | ;
 // NOTE: This might be wrong wrt the identifier portion
 Type = Primitive | Array | ID;
 
-// What is void... why make a language with void......
 Primitive = VOID | BOOLEAN | INT;
 
 // An array is a typename, left bracket then right bracket
@@ -102,12 +103,12 @@ Param = Type ID;
 
 Statement = LocalVar | Block | IfElse | While | Break | Return | ExprStatement;
 
+StatementList = Statement StatementList | ;
+
 LocalVar = Type ID SEMICOLON;
 
-Block = LCURLY Statement* RCURLY;
+Block = LCURLY StatementList RCURLY;
 
-// IfThenElse is da wae..........................................
-// The semantics of this language means that a statement if (False) { /.../ } will always return void wtf...
 IfElse = If OptElse;
 
 If = IF LPAREN Expr RPAREN Statement;

--- a/Lab2/src/frontend/parser.beaver
+++ b/Lab2/src/frontend/parser.beaver
@@ -71,7 +71,10 @@ Declaration = FuncDec | TypeDec | FieldDec;
 
 // A function declaration consists of a few things but it'll be omitted here for brevity
 // in EBNF: FuncDec = Accessibility Type IDENT "(" ParamList ")" "{" Statements? "}"
-FuncDec = AccSpec Type ID LPAREN ParamList? RPAREN LCURLY Statement* RCURLY;
+FuncDec = AccSpec Type ID LPAREN OptParamList RPAREN LCURLY Statement* RCURLY;
+
+// Equivalent to matching either paramlist or nothing
+OptParamList = ParamList | ;
 
 ParamList = Type ID | Param COMMA Type ID;
 
@@ -81,7 +84,7 @@ FieldDec = AccSpec Type ID SEMICOLON;
 // in EBNF: TypeDec = Accessibility Type IDENT "=" IDENT ";"
 TypeDec = AccSpec TYPE ID EQL STRING_LITERAL SEMICOLON; // TYPE is the terminal
 
-AccSpec = PUBLIC?;
+AccSpec = PUBLIC | ;
 
 // A type name is either a primitive, an array of an identifier.
 // NOTE: This might be wrong wrt the identifier portion
@@ -103,23 +106,27 @@ Block = LCURLY Statement* RCURLY;
 
 // IfThenElse is da wae..........................................
 // The semantics of this language means that a statement if (False) { /.../ } will always return void wtf...
-IfElse = If Else?;
+IfElse = If OptElse;
 
 If = IF LPAREN Expr RPAREN Statement;
 
 Else = ELSE Statement;
 
+OptElse = Else | ;
+
 While = WHILE LPAREN Expr RPAREN Statement;
 
 Break = BREAK SEMICOLON;
 
-Return = RETURN Expr? SEMICOLON;
+Return = RETURN OptExpr SEMICOLON;
 
 // NOTE: Better naming could be helpful here
 // Broken into 2 to allow the Or grouping to occur separately for readability
 ExprStatement = Expr SEMICOLON;
 
 Expr = Assignment | RightHandExpr;
+
+OptExpr = Expr | ;
 
 Assignment = LeftHandExpr EQL Expr;
 

--- a/Lab2/src/frontend/parser.beaver
+++ b/Lab2/src/frontend/parser.beaver
@@ -59,12 +59,14 @@ EBNF Notation:
 // We define them here to avoid ambiguity later on
 // through forms such as Import = "" | concreteImport
 // in EBNF: Module = IDENT "{" imports, dec "}"
-Module = MODULE ID LCURLY Import* Declaration* RCURLY;
+Module = MODULE ID LCURLY ImportList Declaration* RCURLY;
 
 // An import statement consists of 0 or more import statements.
 // As explained above, we omit the optional declaration here in favour of expressing it in Module.
 // In EBNF: Import = "import" IDENT ";"
 Import = IMPORT ID SEMICOLON;
+
+ImportList = Import | ImportList Import | ;
 
 // A declaration is function or type or field declaration
 Declaration = FuncDec | TypeDec | FieldDec;


### PR DESCRIPTION
**What's Changed**
1. Rewrite to remove Beaver's special syntax, namely:
    - `?`: optional symbol, rewritten using the following rule: `x = y?;` => `x = y | ;`  should work identically because we are now matching on the empty token, which is satisfied by everything. 
    - `*`: optional list of the symbol, rewritten using the following rule: `x = y*;` => `x = y x | ;`. 
        -   now, the base case is either the empty symbol or a base symbol + (compound). this is inductively equal to either base + ((base + compound) | empty), which follows what we want.